### PR TITLE
Add modular trading bot skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,40 @@
 # KoreaEx
-Trace the crypto listing on Korea Exchanges and follow the strategy to make profit.
+
+A simple prototype trading bot that monitors new coin listings on Korean cryptocurrency exchanges and applies a listing strategy.
+
+## Project structure
+
+```
+trading_bot/
+├── config/
+│   ├── .env
+│   └── config.yaml
+├── logs/
+├── modules/
+│   ├── spider.py
+│   ├── exchange.py
+│   ├── strategy.py
+│   ├── executor.py
+│   └── history.py
+├── main.py
+├── requirements.txt
+└── README.md
+```
+
+## Usage
+
+1. Install dependencies:
+
+```
+pip install -r requirements.txt
+```
+
+2. Fill in `config/.env` with your API credentials.
+
+3. Run the bot:
+
+```
+python main.py
+```
+
+The `config/config.yaml` file contains the default strategy parameters (taken from optimisation results). The bot currently logs detected new listings and shows how modules interact; extend `strategy` and `executor` modules for real trading.

--- a/config/.env
+++ b/config/.env
@@ -1,0 +1,2 @@
+API_KEY=
+API_SECRET=

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,0 +1,11 @@
+exchange: upbit
+strategy:
+  take_profit: 15
+  pullback_threshold: 0.15
+  add_position_interval: 0.15
+  max_add_times: 4
+  high_lookback_hours: 8
+  min_high_age_hours: 3
+  listing_delay_hours: 2
+  initial_position: 10
+  position_multiplier: 2

--- a/main.py
+++ b/main.py
@@ -1,0 +1,42 @@
+"""Entry point tying together the trading bot modules."""
+
+import time
+from pathlib import Path
+import os
+
+import yaml
+from dotenv import load_dotenv
+
+from modules.exchange import Exchange
+from modules.spider import ListingSpider
+from modules.strategy import StrategyConfig, ListingStrategy
+from modules.executor import Executor
+from modules.history import TradeHistory
+
+
+def load_config() -> dict:
+    with open("config/config.yaml", "r") as f:
+        return yaml.safe_load(f)
+
+
+def main():
+    load_dotenv("config/.env")
+    cfg = load_config()
+
+    exchange = Exchange(cfg["exchange"], os.getenv("API_KEY"), os.getenv("API_SECRET"))
+    spider = ListingSpider(exchange.client)
+    strategy = ListingStrategy(StrategyConfig(**cfg["strategy"]))
+    executor = Executor(exchange)
+    history = TradeHistory(Path("logs/trades.csv"))
+
+    while True:
+        new_listings = spider.fetch_new_listings()
+        for symbol in new_listings:
+            print(f"New listing detected: {symbol}")
+            strategy.record_listing_time(symbol)
+        # Sleep to avoid spamming the exchange
+        time.sleep(60)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/exchange.py
+++ b/modules/exchange.py
@@ -1,0 +1,22 @@
+"""Exchange connector using ccxt for Korean exchanges."""
+
+from typing import Optional
+import ccxt
+
+
+class Exchange:
+    """Wrapper around ccxt exchange with basic helpers."""
+
+    def __init__(self, exchange_id: str, api_key: Optional[str] = None, secret: Optional[str] = None):
+        cls = getattr(ccxt, exchange_id)
+        self.client = cls({'apiKey': api_key, 'secret': secret})
+
+    def load_markets(self):
+        return self.client.load_markets()
+
+    def fetch_ohlcv(self, symbol: str, timeframe: str = '1m', limit: int = 200):
+        return self.client.fetch_ohlcv(symbol, timeframe=timeframe, limit=limit)
+
+    def get_current_price(self, symbol: str) -> float:
+        ticker = self.client.fetch_ticker(symbol)
+        return ticker['last']

--- a/modules/executor.py
+++ b/modules/executor.py
@@ -1,0 +1,19 @@
+"""Execution module handling orders."""
+
+import logging
+
+
+class Executor:
+    """Simple executor that logs buy and sell actions."""
+
+    def __init__(self, exchange):
+        self.exchange = exchange
+        self.logger = logging.getLogger(__name__)
+
+    def market_buy(self, symbol: str, amount: float):
+        self.logger.info(f"Buying {amount} {symbol}")
+        # self.exchange.client.create_market_buy_order(symbol, amount)
+
+    def market_sell(self, symbol: str, amount: float):
+        self.logger.info(f"Selling {amount} {symbol}")
+        # self.exchange.client.create_market_sell_order(symbol, amount)

--- a/modules/history.py
+++ b/modules/history.py
@@ -1,0 +1,22 @@
+"""Trade history storage."""
+
+from pathlib import Path
+from typing import Dict, List
+import pandas as pd
+
+
+class TradeHistory:
+    """Store trade records in a CSV file."""
+
+    def __init__(self, path: Path):
+        self.path = path
+        if not self.path.exists():
+            df = pd.DataFrame(columns=["timestamp", "symbol", "side", "price", "amount"])
+            df.to_csv(self.path, index=False)
+
+    def append(self, record: Dict):
+        df = pd.DataFrame([record])
+        df.to_csv(self.path, mode="a", header=False, index=False)
+
+    def load(self) -> List[Dict]:
+        return pd.read_csv(self.path).to_dict("records")

--- a/modules/spider.py
+++ b/modules/spider.py
@@ -1,0 +1,20 @@
+"""Spider to track new coin listings on a given Korean exchange using ccxt."""
+
+from typing import List, Set
+import ccxt
+
+
+class ListingSpider:
+    """Fetches new coin listings from a ccxt exchange instance."""
+
+    def __init__(self, exchange: ccxt.Exchange):
+        self.exchange = exchange
+        self.known_markets: Set[str] = set()
+
+    def fetch_new_listings(self) -> List[str]:
+        """Return a list of symbols that were listed since last call."""
+        markets = self.exchange.load_markets()
+        tickers = set(markets.keys())
+        new = sorted(tickers - self.known_markets)
+        self.known_markets = tickers
+        return new

--- a/modules/strategy.py
+++ b/modules/strategy.py
@@ -1,0 +1,72 @@
+"""Strategy module for trading newly listed coins."""
+
+from dataclasses import dataclass
+from typing import Dict
+import time
+
+
+@dataclass
+class StrategyConfig:
+    take_profit: float = 15               # percent
+    pullback_threshold: float = 0.15      # fraction
+    add_position_interval: float = 0.15   # fraction
+    max_add_times: int = 4
+    high_lookback_hours: int = 8
+    min_high_age_hours: int = 3
+    listing_delay_hours: int = 2
+    initial_position: float = 10
+    position_multiplier: float = 2
+
+
+class ListingStrategy:
+    """Implements the entry and exit logic for newly listed coins."""
+
+    def __init__(self, config: StrategyConfig):
+        self.config = config
+        self.entry_price: Dict[str, float] = {}
+        self.high_price: Dict[str, float] = {}
+        self.add_times: Dict[str, int] = {}
+        self.listing_time: Dict[str, float] = {}
+
+    def record_listing_time(self, symbol: str):
+        self.listing_time.setdefault(symbol, time.time())
+
+    def should_buy(self, symbol: str, current_price: float) -> bool:
+        listing_time = self.listing_time.get(symbol)
+        if listing_time is None:
+            return False
+        if time.time() - listing_time < self.config.listing_delay_hours * 3600:
+            return False
+        self.entry_price.setdefault(symbol, current_price)
+        self.high_price.setdefault(symbol, current_price)
+        self.add_times.setdefault(symbol, 0)
+        return True
+
+    def update_high(self, symbol: str, current_price: float):
+        high = self.high_price.get(symbol, current_price)
+        if current_price > high:
+            self.high_price[symbol] = current_price
+        return self.high_price[symbol]
+
+    def should_add_position(self, symbol: str, current_price: float) -> bool:
+        base = self.entry_price.get(symbol)
+        if base is None:
+            return False
+        add_times = self.add_times.get(symbol, 0)
+        target = base * (1 + self.config.add_position_interval * (add_times + 1))
+        if current_price >= target and add_times < self.config.max_add_times:
+            self.add_times[symbol] = add_times + 1
+            return True
+        return False
+
+    def should_take_profit(self, symbol: str, current_price: float) -> bool:
+        base = self.entry_price.get(symbol)
+        if base is None:
+            return False
+        profit = (current_price - base) / base * 100
+        if profit >= self.config.take_profit:
+            return True
+        pullback = 1 - current_price / self.high_price.get(symbol, current_price)
+        if pullback >= self.config.pullback_threshold:
+            return True
+        return False

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+ccxt
+pandas
+python-dotenv
+PyYAML


### PR DESCRIPTION
## Summary
- set up modular trading bot scaffold with spider, exchange connector, strategy logic, executor and trade history storage
- add configuration files and main loop wiring the components together
- document project structure and usage

## Testing
- `python -m py_compile $(find . -name '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688f00458c708320b41993b5b046cf5c